### PR TITLE
share and claim screen qr code fixes

### DIFF
--- a/ui_components/QrModal.tsx
+++ b/ui_components/QrModal.tsx
@@ -14,10 +14,11 @@ export interface IQrModal {
     open: boolean;
     setOpen: (val: boolean) => void;
     value: string;
+    showCopy?: boolean;
 }
 
 export const QrModal: FC<IQrModal> = (props) => {
-    const { open, setOpen, value } = props;
+    const { open, setOpen, value, showCopy } = props;
 
     const [showOptions, setShowOptions] = useState(true);
 
@@ -65,6 +66,7 @@ export const QrModal: FC<IQrModal> = (props) => {
                                                     isShareQr={true}
                                                     widthPx={240}
                                                     heightPx={240}
+                                                    showCopy={showCopy}
                                                 />
                                             </div>
                                         </div>

--- a/ui_components/ShareLinkPage.tsx
+++ b/ui_components/ShareLinkPage.tsx
@@ -171,7 +171,9 @@ const ShareLink: FC<IShareLink> = (props) => {
             setTokenValue(getTokenValueFormatted(bgNum, 6, false));
             setIsLoading(false);
             const formatBal = bgNum * res.data.ethereum.usd;
-            setLinkValueUsd(getCurrencyFormattedNumber(formatBal, 2, "USD", true));
+            setLinkValueUsd(
+                getCurrencyFormattedNumber(roundDownToTenth(formatBal), 2, "USD", true),
+            );
             const zeroBal =
                 getCurrencyFormattedNumber(formatBal, 2, "USD", true) === "$0";
             setHeadingText(
@@ -319,6 +321,10 @@ const ShareLink: FC<IShareLink> = (props) => {
         } else {
             return true;
         }
+    };
+
+    const roundDownToTenth = (number: number) => {
+        return Math.round(number * 10) / 10;
     };
 
     return (
@@ -489,7 +495,12 @@ const ShareLink: FC<IShareLink> = (props) => {
                 handlePublicAddressTransaction={handlePublicAddressTransaction}
             />
             <ShareBtnModal open={openShareModal} setOpen={setOpenShareModal} />
-            <QrModal open={showQr} setOpen={setShowQr} value={fromAddress} />
+            <QrModal
+                open={showQr}
+                setOpen={setShowQr}
+                value={fromAddress}
+                showCopy={false}
+            />
             {isClaimSuccessful && (
                 <Confetti
                     width={2400}

--- a/ui_components/loadchest/LoadChestComponent.tsx
+++ b/ui_components/loadchest/LoadChestComponent.tsx
@@ -119,6 +119,7 @@ export const LoadChestComponent: FC<ILoadChestComponent> = (props) => {
         const valueWithoutDollarSign = val.replace(/[^\d.]/g, "");
         const tokenIputValue = Number(valueWithoutDollarSign) / Number(tokenPrice);
         setInputValue(getTokenValueFormatted(Number(tokenIputValue)));
+        setBtnDisable(false);
     };
 
     const handleInputChange = (val: string) => {

--- a/ui_components/loadchest/QRComponent.tsx
+++ b/ui_components/loadchest/QRComponent.tsx
@@ -70,9 +70,10 @@ export interface IQRComponent {
     isShareQr?: boolean;
     widthPx: number;
     heightPx: number;
+    showCopy?: boolean;
 }
 export const QRComponent: FC<IQRComponent> = (props) => {
-    const { walletAddress, isShareQr, widthPx, heightPx } = props;
+    const { walletAddress, isShareQr, widthPx, heightPx, showCopy } = props;
     const [options] = useState<Options>({
         width: widthPx,
         height: heightPx,
@@ -129,7 +130,7 @@ export const QRComponent: FC<IQRComponent> = (props) => {
             </p>
             <div className="flex items-center justify-center" ref={ref} />
 
-            {!isShareQr ? (
+            {!showCopy ? (
                 <div>
                     <div className="flex items-center justify-center">
                         <div className="w-fit mt-[15px] border-dashed border border-secondary-300 dark:border-secondaryDark-300 rounded-[10px] flex justify-center items-start md:items-center p-2">

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -73,9 +73,9 @@ export const trimAddress = (val: string) => {
     return firstFour + "..." + lastFour;
 };
 export const trimLink = (val: string) => {
-    const firstTen = val.substring(0, 6);
-    const lastTen = val.substring(val.length - 15, val.length);
-    return firstTen + "..." + lastTen;
+    const firstTwenty = val.substring(0, 20);
+    const lastEight = val.substring(val.length - 8, val.length);
+    return firstTwenty + "..." + lastEight;
 };
 
 export const getCurrencyFormattedNumber = (
@@ -183,7 +183,7 @@ export const getExponentialFixedNumber = (num: number) => {
 };
 
 export const copyToClipBoard = (val: string) => {
-    navigator.clipboard.writeText(`https://blocktheory.com/blog/${val}`);
+    navigator.clipboard.writeText(`${val}`);
 };
 
 export const encryptAndEncodeHexStrings = (hexString1: string, hexString2: string) => {


### PR DESCRIPTION
- 
- fixed the following issues
- on click quick selections of $1, $2 or $5 -- create link button is not getting enabled 
- url in the share popup -- truncate the end of the url, make sure domain is visible 
-  share card -- keep only one decimal, if $2.01 -- should show as $2 and if $2.5 should show as $2.5
-  add address with copy option in the qr code modal in the share link page 